### PR TITLE
feat: update JSON for alias commands

### DIFF
--- a/schemas/alias-list.json
+++ b/schemas/alias-list.json
@@ -24,90 +24,21 @@
           "type": "string"
         },
         "error": {
-          "$ref": "#/definitions/SfError"
-        }
-      },
-      "required": ["alias"],
-      "additionalProperties": false
-    },
-    "SfError": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "stack": {
-          "type": "string"
-        },
-        "cause": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string"
             },
-            "cause": {
-              "$ref": "#/definitions/alias-1501530572-0-211-1501530572-0-1533943985149"
-            },
-            "fullStack": {
-              "type": "string"
-            },
             "message": {
-              "type": "string"
-            },
-            "stack": {
               "type": "string"
             }
           },
-          "required": ["message", "name"],
-          "description": "Any `Error` compatible with the `NamedError` type signature."
-        },
-        "actions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Action messages. Hints to the users regarding what can be done to fix related issues."
-        },
-        "exitCode": {
-          "type": "number",
-          "description": "SfdxCommand can return this process exit code."
-        },
-        "context": {
-          "type": "string",
-          "description": "The related context for this error."
-        },
-        "data": {}
-      },
-      "required": ["exitCode", "message", "name"],
-      "additionalProperties": false,
-      "description": "A generalized sfdx error which also contains an action. The action is used in the CLI to help guide users past the error.\n\nTo throw an error in a synchronous function you must either pass the error message and actions directly to the constructor, e.g.\n\n``` // To load a message bundle (Note that __dirname should contain a messages folder) Messages.importMessagesDirectory(__dirname); const messages = Messages.load('myPackageName', 'myBundleName');\n\n// To throw a non-bundle based error: throw new SfError(message.getMessage('myError'), 'MyErrorName'); ```"
-    },
-    "alias-1501530572-0-211-1501530572-0-1533943985149": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "cause": {
-          "$ref": "#/definitions/alias-1501530572-0-211-1501530572-0-1533943985149"
-        },
-        "fullStack": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "stack": {
-          "type": "string"
+          "required": ["name", "message"],
+          "additionalProperties": false
         }
       },
-      "required": ["message", "name"],
-      "description": "Any `Error` compatible with the `NamedError` type signature."
+      "required": ["alias"],
+      "additionalProperties": false
     }
   }
 }

--- a/schemas/alias-set.json
+++ b/schemas/alias-set.json
@@ -24,90 +24,21 @@
           "type": "string"
         },
         "error": {
-          "$ref": "#/definitions/SfError"
-        }
-      },
-      "required": ["alias"],
-      "additionalProperties": false
-    },
-    "SfError": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "stack": {
-          "type": "string"
-        },
-        "cause": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string"
             },
-            "cause": {
-              "$ref": "#/definitions/alias-1283098157-0-211-1283098157-0-1533943985149"
-            },
-            "fullStack": {
-              "type": "string"
-            },
             "message": {
-              "type": "string"
-            },
-            "stack": {
               "type": "string"
             }
           },
-          "required": ["message", "name"],
-          "description": "Any `Error` compatible with the `NamedError` type signature."
-        },
-        "actions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Action messages. Hints to the users regarding what can be done to fix related issues."
-        },
-        "exitCode": {
-          "type": "number",
-          "description": "SfdxCommand can return this process exit code."
-        },
-        "context": {
-          "type": "string",
-          "description": "The related context for this error."
-        },
-        "data": {}
-      },
-      "required": ["exitCode", "message", "name"],
-      "additionalProperties": false,
-      "description": "A generalized sfdx error which also contains an action. The action is used in the CLI to help guide users past the error.\n\nTo throw an error in a synchronous function you must either pass the error message and actions directly to the constructor, e.g.\n\n``` // To load a message bundle (Note that __dirname should contain a messages folder) Messages.importMessagesDirectory(__dirname); const messages = Messages.load('myPackageName', 'myBundleName');\n\n// To throw a non-bundle based error: throw new SfError(message.getMessage('myError'), 'MyErrorName'); ```"
-    },
-    "alias-1283098157-0-211-1283098157-0-1533943985149": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "cause": {
-          "$ref": "#/definitions/alias-1283098157-0-211-1283098157-0-1533943985149"
-        },
-        "fullStack": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "stack": {
-          "type": "string"
+          "required": ["name", "message"],
+          "additionalProperties": false
         }
       },
-      "required": ["message", "name"],
-      "description": "Any `Error` compatible with the `NamedError` type signature."
+      "required": ["alias"],
+      "additionalProperties": false
     }
   }
 }

--- a/schemas/alias-unset.json
+++ b/schemas/alias-unset.json
@@ -24,90 +24,21 @@
           "type": "string"
         },
         "error": {
-          "$ref": "#/definitions/SfError"
-        }
-      },
-      "required": ["alias"],
-      "additionalProperties": false
-    },
-    "SfError": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "stack": {
-          "type": "string"
-        },
-        "cause": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "name": {
               "type": "string"
             },
-            "cause": {
-              "$ref": "#/definitions/alias-1283098157-0-211-1283098157-0-1533943985149"
-            },
-            "fullStack": {
-              "type": "string"
-            },
             "message": {
-              "type": "string"
-            },
-            "stack": {
               "type": "string"
             }
           },
-          "required": ["message", "name"],
-          "description": "Any `Error` compatible with the `NamedError` type signature."
-        },
-        "actions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Action messages. Hints to the users regarding what can be done to fix related issues."
-        },
-        "exitCode": {
-          "type": "number",
-          "description": "SfdxCommand can return this process exit code."
-        },
-        "context": {
-          "type": "string",
-          "description": "The related context for this error."
-        },
-        "data": {}
-      },
-      "required": ["exitCode", "message", "name"],
-      "additionalProperties": false,
-      "description": "A generalized sfdx error which also contains an action. The action is used in the CLI to help guide users past the error.\n\nTo throw an error in a synchronous function you must either pass the error message and actions directly to the constructor, e.g.\n\n``` // To load a message bundle (Note that __dirname should contain a messages folder) Messages.importMessagesDirectory(__dirname); const messages = Messages.load('myPackageName', 'myBundleName');\n\n// To throw a non-bundle based error: throw new SfError(message.getMessage('myError'), 'MyErrorName'); ```"
-    },
-    "alias-1283098157-0-211-1283098157-0-1533943985149": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "cause": {
-          "$ref": "#/definitions/alias-1283098157-0-211-1283098157-0-1533943985149"
-        },
-        "fullStack": {
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "stack": {
-          "type": "string"
+          "required": ["name", "message"],
+          "additionalProperties": false
         }
       },
-      "required": ["message", "name"],
-      "description": "Any `Error` compatible with the `NamedError` type signature."
+      "required": ["alias"],
+      "additionalProperties": false
     }
   }
 }

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { SfError } from '@salesforce/core';
 import { ux } from '@oclif/core';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 
@@ -14,7 +13,10 @@ export type AliasResult = {
   value?: string;
   success?: boolean;
   message?: string;
-  error?: SfError;
+  error?: {
+    name: string;
+    message: string;
+  };
 };
 
 export type AliasResults = AliasResult[];

--- a/src/commands/alias/set.ts
+++ b/src/commands/alias/set.ts
@@ -44,8 +44,8 @@ export default class AliasSet extends AliasCommand<AliasResults> {
           return { alias, success: true, value };
         }
       } catch (err) {
-        const error = err as SfError;
-        return { alias, success: false, error, value };
+        const { name, message } = err as SfError;
+        return { alias, success: false, error: { name, message }, value };
       }
     });
 

--- a/src/commands/alias/unset.ts
+++ b/src/commands/alias/unset.ts
@@ -69,8 +69,8 @@ export default class AliasUnset extends AliasCommand<AliasResults> {
         stateAggregator.aliases.unset(alias);
         return { alias, value, success: true };
       } catch (err) {
-        const error = err as SfError;
-        return { alias, value, success: false, error };
+        const { name, message } = err as SfError;
+        return { alias, value, success: false, error: { name, message } };
       }
     });
 

--- a/test/commands/alias/set.nut.ts
+++ b/test/commands/alias/set.nut.ts
@@ -112,7 +112,10 @@ describe('alias set NUTs', () => {
         {
           alias: 'DevHub',
           success: false,
-          error: { name: 'ValueRequiredError' },
+          error: {
+            name: 'ValueRequiredError',
+            exitCode: 1,
+          },
           message:
             'You must provide a value when setting an alias. Use `sf alias unset my-alias-name` to remove existing aliases.',
         },

--- a/test/commands/alias/set.nut.ts
+++ b/test/commands/alias/set.nut.ts
@@ -112,10 +112,7 @@ describe('alias set NUTs', () => {
         {
           alias: 'DevHub',
           success: false,
-          error: {
-            name: 'ValueRequiredError',
-            exitCode: 1,
-          },
+          error: { name: 'ValueRequiredError' },
           message:
             'You must provide a value when setting an alias. Use `sf alias unset my-alias-name` to remove existing aliases.',
         },


### PR DESCRIPTION
### What does this PR do?

Removes `SfError` from alias commands' JSON. Having `SfError` in the return types was causing the generated schema to change anytime the sfdx-core version is bumped. Generally speaking, classes should not be included in the JSON

### What issues does this PR fix or reference?
[skip-validate-pr]