### PR TITLE
fix: update unset nut for plugin core changes

### DIFF
--- a/test/commands/sfdx/config/unset.nut.ts
+++ b/test/commands/sfdx/config/unset.nut.ts
@@ -23,6 +23,8 @@ describe('config:unset NUTs', async () => {
         message:
           'You must provide one or more configuration variables to unset. Run "sf config list" to see the configuration variables you\'ve previously set.',
         name: 'NoConfigKeysFoundError',
+        commandName: 'UnSet',
+        context: 'UnSet',
         status: 1,
         code: 1,
         exitCode: 1,


### PR DESCRIPTION
### What does this PR do?
Updates the unset nut expectation for json response to match recent changes to sf-plugins-core

### What issues does this PR fix or reference?
@W-00000000@