### PR TITLE
fix: warn when attempting to unset a global config without flag

### DIFF
--- a/messages/config.unset.md
+++ b/messages/config.unset.md
@@ -27,3 +27,7 @@ You must provide one or more configuration variables to unset. Run "sf config li
 # didYouMean
 
 Did you mean %s?
+
+# unsetGlobalWarning
+
+The %s config is still set globally, unset it by using the --global flag.

--- a/messages/config.unset.md
+++ b/messages/config.unset.md
@@ -30,4 +30,4 @@ Did you mean %s?
 
 # unsetGlobalWarning
 
-The %s config is still set globally, unset it by using the --global flag.
+The %s config variable is still set globally, unset it by using the --global flag.

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -37,14 +37,16 @@ export class UnSet extends SfCommand<SetOrUnsetConfigCommandResult> {
       throw messages.createError('error.NoConfigKeysFound');
     }
     const config = await Config.create(Config.getDefaultOptions(flags.global));
+    const globalConfig = await Config.create(Config.getDefaultOptions(true));
 
+    await globalConfig.read();
     await config.read();
     for (const key of argv as string[]) {
       try {
         const resolvedName = this.configAggregator.getPropertyMeta(key)?.newKey ?? key;
         config.unset(resolvedName);
 
-        if (!flags.global && this.configAggregator.getLocation(resolvedName) === 'Global') {
+        if (!flags.global && globalConfig.has(resolvedName)) {
           // If the config var is still set globally after an unset and the user didn't have the `--global` flag set, warn them.
           this.warn(messages.getMessage('unsetGlobalWarning', [resolvedName]));
         }

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -45,7 +45,7 @@ export class UnSet extends SfCommand<SetOrUnsetConfigCommandResult> {
         config.unset(resolvedName);
 
         if (!flags.global && this.configAggregator.getLocation(resolvedName) === 'Global') {
-          // if the user wanted to unset a global value, and it's not in the global, warn them
+          // If the config var is still set globally after an unset and the user didn't have the `--global` flag set, warn them.
           this.warn(messages.getMessage('unsetGlobalWarning', [resolvedName]));
         }
         this.responses.successes.push({ name: resolvedName, success: true });

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -37,7 +37,7 @@ export class UnSet extends SfCommand<SetOrUnsetConfigCommandResult> {
       throw messages.createError('error.NoConfigKeysFound');
     }
     const config = await Config.create(Config.getDefaultOptions(flags.global));
-    const globalConfig = await Config.create(Config.getDefaultOptions(true));
+    const globalConfig = flags.global ? config : await Config.create(Config.getDefaultOptions(true));
 
     await globalConfig.read();
     await config.read();

--- a/test/commands/config/unset.nut.ts
+++ b/test/commands/config/unset.nut.ts
@@ -36,25 +36,67 @@ describe('config unset NUTs', async () => {
       execCmd('config set org-api-version=51.0 --global');
     });
 
-    it('lists singular config correctly', () => {
-      const result = execCmd<SetOrUnsetConfigCommandResult>('config unset org-api-version --json', {
-        ensureExitCode: 0,
-      }).jsonOutput?.result.successes;
-      expect(result).to.deep.equal([
-        {
-          name: 'org-api-version',
-          success: true,
-        },
-      ]);
-    });
-
-    it('lists singular result correctly stdout', () => {
+    it('displays correct stdout on success', () => {
       const res = execCmd('config unset org-api-version').shellOutput.stdout;
       expect(res).to.include('Unset Config');
       expect(res).to.include('org-api-version');
       expect(res).to.include('Name');
       expect(res).to.include('Success');
       expect(res).to.include('true');
+    });
+
+    it('unsets the config globally', () => {
+      const res = execCmd('config:unset apiVersion --global --json', { ensureExitCode: 0 });
+      expect(res.jsonOutput).to.deep.equal({
+        result: {
+          failures: [],
+          successes: [
+            {
+              name: 'org-api-version',
+              success: true,
+            },
+          ],
+        },
+        status: 0,
+        warnings: ['Deprecated config name: apiVersion. Please use org-api-version instead.'],
+      });
+    });
+
+    it('warns when nothing unset locally and config still set globally', () => {
+      const res = execCmd('config:unset org-api-version --json', { ensureExitCode: 0 });
+      expect(res.jsonOutput).to.deep.equal({
+        result: {
+          failures: [],
+          successes: [
+            {
+              name: 'org-api-version',
+              success: true,
+            },
+          ],
+        },
+        status: 0,
+        warnings: ['The org-api-version config variable is still set globally, unset it by using the --global flag.'],
+      });
+    });
+
+    it('warns when unset locally and config still set globally', () => {
+      // This will result in apiVersion being set both globally and locally
+      execCmd('config:set org-api-version=52.0', { ensureExitCode: 0 });
+
+      const res = execCmd('config:unset org-api-version --json', { ensureExitCode: 0 });
+      expect(res.jsonOutput).to.deep.equal({
+        result: {
+          failures: [],
+          successes: [
+            {
+              name: 'org-api-version',
+              success: true,
+            },
+          ],
+        },
+        status: 0,
+        warnings: ['The org-api-version config variable is still set globally, unset it by using the --global flag.'],
+      });
     });
   });
 

--- a/test/commands/sfdx/config/unset.nut.ts
+++ b/test/commands/sfdx/config/unset.nut.ts
@@ -43,8 +43,28 @@ describe('config:unset NUTs', async () => {
       execCmd('config:set apiVersion=51.0 --global');
     });
 
-    it('lists singular config correctly', () => {
+    it('warns when config still set globally', () => {
       const res = execCmd('config:unset apiVersion --json', { ensureExitCode: 0 });
+      expect(res.jsonOutput).to.deep.equal({
+        result: {
+          failures: [],
+          successes: [
+            {
+              name: 'org-api-version',
+              success: true,
+            },
+          ],
+        },
+        status: 0,
+        warnings: [
+          'Deprecated config name: apiVersion. Please use org-api-version instead.',
+          'The org-api-version config variable is still set globally, unset it by using the --global flag.',
+        ],
+      });
+    });
+
+    it('unsets the config globally', () => {
+      const res = execCmd('config:unset apiVersion --global --json', { ensureExitCode: 0 });
       expect(res.jsonOutput).to.deep.equal({
         result: {
           failures: [],
@@ -101,7 +121,9 @@ describe('config:unset NUTs', async () => {
         warnings: [
           'Deprecated config name: restDeploy. Please use org-metadata-rest-deploy instead.',
           'Deprecated config name: apiVersion. Please use org-api-version instead.',
+          'The org-api-version config variable is still set globally, unset it by using the --global flag.',
           'Deprecated config name: maxQueryLimit. Please use org-max-query-limit instead.',
+          'The org-max-query-limit config variable is still set globally, unset it by using the --global flag.',
         ],
       });
     });

--- a/test/commands/sfdx/config/unset.nut.ts
+++ b/test/commands/sfdx/config/unset.nut.ts
@@ -40,10 +40,33 @@ describe('config:unset NUTs', async () => {
 
   describe('config:unset with singular result', () => {
     beforeEach(() => {
-      execCmd('config:set apiVersion=51.0 --global');
+      execCmd('config:set apiVersion=51.0 --global', { ensureExitCode: 0 });
     });
 
-    it('warns when config still set globally', () => {
+    it('warns when nothing unset locally and config still set globally', () => {
+      const res = execCmd('config:unset apiVersion --json', { ensureExitCode: 0 });
+      expect(res.jsonOutput).to.deep.equal({
+        result: {
+          failures: [],
+          successes: [
+            {
+              name: 'org-api-version',
+              success: true,
+            },
+          ],
+        },
+        status: 0,
+        warnings: [
+          'Deprecated config name: apiVersion. Please use org-api-version instead.',
+          'The org-api-version config variable is still set globally, unset it by using the --global flag.',
+        ],
+      });
+    });
+
+    it('warns when unset locally and config still set globally', () => {
+      // This will result in apiVersion being set both globally and locally
+      execCmd('config:set apiVersion=52.0', { ensureExitCode: 0 });
+
       const res = execCmd('config:unset apiVersion --json', { ensureExitCode: 0 });
       expect(res.jsonOutput).to.deep.equal({
         result: {


### PR DESCRIPTION
### What does this PR do?
warns when attempting to unset a global config without the `--global` flag because the output is confusing
### What issues does this PR fix or reference?
@W-13825061@