### PR TITLE
fix: add link to doc with full list of config vars

### DIFF
--- a/messages/config.get.md
+++ b/messages/config.get.md
@@ -6,6 +6,8 @@ Get the value of a configuration variable.
 
 Run "sf config list" to see all the configuration variables you've set. Global configuration variable are always displayed; local ones are displayed if you run the command in a project directory. Run "sf config set" to set a configuration variable.
 
+For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
+
 # examples
 
 - Get the value of the "target-org" configuration variable.

--- a/messages/config.list.md
+++ b/messages/config.list.md
@@ -6,6 +6,8 @@ List the configuration variables that you've previously set.
 
 Global configuration variables apply to any Salesforce DX project and are always displayed. If you run this command from a project directory, local configuration variables are also displayed.
 
+For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
+
 # examples
 
 - List both global configuration variables and those local to your project:

--- a/messages/config.set.md
+++ b/messages/config.set.md
@@ -16,6 +16,8 @@ The resolution order if you've set a flag value in multiple ways is as follows:
 
 Run "sf config list" to see the configuration variables you've already set and their level (local or global).
 
+For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
+
 # examples
 
 - Set the local target-org configuration variable to an org username:

--- a/messages/config.unset.md
+++ b/messages/config.unset.md
@@ -6,6 +6,8 @@ Unset local or global configuration variables.
 
 Local configuration variables apply only to your current project. Global configuration variables apply in any Salesforce DX project.
 
+For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
+
 # examples
 
 - Unset the local "target-org" configuration variable:


### PR DESCRIPTION
### What does this PR do?

Adds link to the Setup Guide's topic with full list of config vars to the descriptions of each "sf config" command. 

### What issues does this PR fix or reference?
@W-14131604@