### PR TITLE
fix: clean up help for "config list"

### DIFF
--- a/messages/config.get.md
+++ b/messages/config.get.md
@@ -4,9 +4,9 @@ Get the value of a configuration variable.
 
 # description
 
-Run "sf config list" to see all the configuration variables you've set. Global configuration variable are always displayed; local ones are displayed if you run the command in a project directory. Run "sf config set" to set a configuration variable.
+Run "sf config list" to see the configuration variables you've already set and their level (local or global).
 
-For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
+Run "sf config set" to set a configuration variable. For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
 
 # examples
 

--- a/messages/config.list.md
+++ b/messages/config.list.md
@@ -4,9 +4,9 @@ List the configuration variables that you've previously set.
 
 # description
 
-A config variable can be global or local, depending on whether you used the --global flag when you set it. Local config variables apply only to the current project and take precedence over global config variables, which apply to all projects. Both global and local config variables take precedence over their equivalent environment variables.
+A config variable can be global or local, depending on whether you used the --global flag when you set it. Local config variables apply only to the current project and override global config variables, which apply to all projects.  You can set all config variables as environment variables. Environment variables override their equivalent local and global config variables.
 
-The output of this command takes into account your current context. For example, let's say you run this command from a Salesforce DX project in which you've locally set the "target-org" config variable. The command displays this local value, even if you've also set "target-org" globally. If you haven't set the config variable locally, then the global value is displayed if set. If you set the SF_TARGET_ORG environment variable, but not "target-org" either globally or locally, then the environment variable value is displayed.
+The output of this command takes into account your current context. For example, let's say you run this command from a Salesforce DX project in which you've locally set the "target-org" config variable. The command displays the local value, even if you've also set "target-org" globally. If you haven't set the config variable locally, then the global value is displayed, if set. If you set the SF_TARGET_ORG environment variable, it's displayed as such and overrides any locally or globally set "target-org" config variable. 
 
 For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
 

--- a/messages/config.list.md
+++ b/messages/config.list.md
@@ -4,12 +4,14 @@ List the configuration variables that you've previously set.
 
 # description
 
-Global configuration variables apply to any Salesforce DX project and are always displayed. If you run this command from a project directory, local configuration variables are also displayed.
+A config variable can be global or local, depending on whether you used the --global flag when you set it. Local config variables apply only to the current project and take precedence over global config variables, which apply to all projects. Both global and local config variables take precedence over their equivalent environment variables.
+
+The output of this command takes into account your current context. For example, let's say you run this command from a Salesforce DX project in which you've locally set the "target-org" config variable. The command displays this local value, even if you've also set "target-org" globally. If you haven't set the config variable locally, then the global value is displayed if set. If you set the SF_TARGET_ORG environment variable, but not "target-org" either globally or locally, then the environment variable value is displayed.
 
 For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
 
 # examples
 
-- List both global configuration variables and those local to your project:
+- List the global and local configuration variables that apply to your current context:
 
   $ <%= config.bin %> <%= command.id %>

--- a/messages/config.set.md
+++ b/messages/config.set.md
@@ -16,25 +16,23 @@ The resolution order if you've set a flag value in multiple ways is as follows:
 
 Run "sf config list" to see the configuration variables you've already set and their level (local or global).
 
+If you're setting a single config variable, you don't need to use an equal sign between the variable and value. But you must use the equal sign if setting multiple config variables.
+
 For the full list of available configuration variables, see https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_config_values.htm.
 
 # examples
 
 - Set the local target-org configuration variable to an org username:
 
-  <%= config.bin %> <%= command.id %> target-org=me@my.org
+  <%= config.bin %> <%= command.id %> target-org me@my.org
 
 - Set the local target-org configuration variable to an alias:
 
-  <%= config.bin %> <%= command.id %> target-org=my-scratch-org
+  <%= config.bin %> <%= command.id %> target-org my-scratch-org
 
-- Set the global target-org configuration variable:
+- Set the global target-org and target-dev-hub configuration variables using aliases:
 
-  <%= config.bin %> <%= command.id %> --global target-org=my-scratch-org
-
-- Set a single configuration variable without using an equal sign; this syntax doesn't work when setting multiple configuration variables:
-
-  <%= config.bin %> <%= command.id %> target-org me@my.com
+  <%= config.bin %> <%= command.id %> --global target-org=my-scratch-org target-dev-hub=my-dev-hub
 
 # flags.global.summary
 

--- a/messages/config.unset.md
+++ b/messages/config.unset.md
@@ -20,7 +20,7 @@ For the full list of available configuration variables, see https://developer.sa
 
 # flags.global.summary
 
-Unset the configuration variables globally, so they can no longer be used from any Salesforce DX project.
+Unset the configuration variables globally.
 
 # error.NoConfigKeysFound
 


### PR DESCRIPTION
### What does this PR do?

Fixes help for "sf config list" to correctly explain that the command displays info based on the current context.  i.e. it shows local if set, global otherwise.   I also cleaned up help for other config commands while I was at it. 

### What issues does this PR fix or reference?

@W-14047109@
