### PR TITLE
fix: bump version of core to 6.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
     "@oclif/core": "^3.18.1",
-    "@salesforce/core": "^6.4.4",
+    "@salesforce/core": "^6.5.0",
     "@salesforce/sf-plugins-core": "^7.1.3",
     "fast-levenshtein": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,10 +1689,34 @@
     semver "^7.5.4"
     ts-retry-promise "^0.7.1"
 
-"@salesforce/core@^6.4.1", "@salesforce/core@^6.4.4", "@salesforce/core@^6.4.7":
+"@salesforce/core@^6.4.1", "@salesforce/core@^6.4.7":
   version "6.4.7"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.4.7.tgz#f15538380aa5c75de697d3c95a2ddbdabae69dbb"
   integrity sha512-gebjw2xC8Z0gqS3lYRQWz7J+PuGZtybotrnnaJbnzzxdfpBFIp6PjW4nt/235BQW9UWFTLaQh+AwkFgmMTTSkA==
+  dependencies:
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/schemas" "^1.6.1"
+    "@salesforce/ts-types" "^2.0.9"
+    "@types/semver" "^7.5.6"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.29"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.17.2"
+    pino-abstract-transport "^1.1.0"
+    pino-pretty "^10.3.1"
+    proper-lockfile "^4.1.2"
+    semver "^7.5.4"
+    ts-retry-promise "^0.7.1"
+
+"@salesforce/core@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.5.0.tgz#a59666270ee3e135520a29d83211685d56443070"
+  integrity sha512-6IwPSvqglX4nUQuIvU5wBX64XS+JxRbxtGLEom/MoAD9QwNXmtU/ZGD/iOvvqV30BL7hzX/xVlJX+cGHsiYg5A==
   dependencies:
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"


### PR DESCRIPTION
### What does this PR do?
bump version of `@salesforce/core` to get new `SF_CAPITALIZE_RECORD_TYPES` config var support.

### What issues does this PR fix or reference?
@W-14750427@