### PR TITLE
test: use real command to unset aliases

### DIFF
--- a/test/commands/sfdx/alias/list.nut.ts
+++ b/test/commands/sfdx/alias/list.nut.ts
@@ -9,9 +9,9 @@ import { expect } from 'chai';
 let testSession: TestSession;
 
 function unsetAll() {
-  execCmd('sfdx alias:unset DevHub');
-  execCmd('sfdx alias:unset Admin');
-  execCmd('sfdx alias:unset user');
+  execCmd('alias:unset DevHub');
+  execCmd('alias:unset Admin');
+  execCmd('alias:unset user');
 }
 
 describe('alias:list NUTs', async () => {

--- a/test/commands/sfdx/alias/set.nut.ts
+++ b/test/commands/sfdx/alias/set.nut.ts
@@ -9,9 +9,9 @@ import { expect } from 'chai';
 let testSession: TestSession;
 
 function unsetAll() {
-  execCmd('sfdx alias:unset DevHub');
-  execCmd('sfdx alias:unset Admin');
-  execCmd('sfdx alias:unset user');
+  execCmd('alias:unset DevHub');
+  execCmd('alias:unset Admin');
+  execCmd('alias:unset user');
 }
 
 describe('alias:set NUTs', async () => {


### PR DESCRIPTION
### What does this PR do?

Passing `sfdx alias:unset` to `execCmd` tells testkit to run `sf sfdx alias:unset` which isn't a real command. This PR removes the `sfdx` from those executions.

### What issues does this PR fix or reference?
[skip-validate-pr]