### PR TITLE
test: ignore line ending differences across os

### DIFF
--- a/test/commands/alias/set.nut.ts
+++ b/test/commands/alias/set.nut.ts
@@ -73,9 +73,9 @@ describe('alias set NUTs', () => {
       }).jsonOutput;
 
       expect(result?.result).to.deep.equal([{ alias: 'foo with space', success: true, value }]);
-      expect(result?.warnings).to.deep.equal([
-        messages.getMessage('warning.spaceAlias', ['foo with space', 'foo with space']),
-      ]);
+      expect(result?.warnings?.map(stripLineEndings)).to.deep.equal(
+        [messages.getMessage('warning.spaceAlias', ['foo with space', 'foo with space'])].map(stripLineEndings)
+      );
     });
 
     it('allow setting a single alias without an equal sign', () => {
@@ -182,3 +182,5 @@ describe('alias set NUTs', () => {
     });
   });
 });
+
+const stripLineEndings = (str?: string): string => str?.replace(/\r?\n|\r/g, '') ?? '';


### PR DESCRIPTION
### What does this PR do?
message comparison ignores line endings for multiline message

### What issues does this PR fix or reference?
https://github.com/salesforcecli/cli/actions/runs/9377235598/job/25819074410#step:8:950